### PR TITLE
Added backup RPC endpoint and retry mechanism

### DIFF
--- a/toolbox/utils/config.py
+++ b/toolbox/utils/config.py
@@ -26,3 +26,5 @@ class validatorToolbox:
     ourExternalIPAddress = urllib.request.urlopen("https://ident.me").read().decode("utf8")
     mainMenuRegular = os.path.join(toolboxLocation, "toolbox", "messages", "regularmenu.txt")
     mainMenuFull = os.path.join(toolboxLocation, "toolbox", "messages", "fullmenu.txt")
+    rpc_endpoints = ['https://rpc.s0.t.hmny.io', 'https://api.harmony.one']
+    rpc_endpoints_max_connection_retries = 10

--- a/toolbox/utils/toolbox.py
+++ b/toolbox/utils/toolbox.py
@@ -53,7 +53,7 @@ def rewardsCollecter() -> None:
 
 
 def menuTopperRegular() -> None:
-    current_epoch = blockchain.get_current_epoch(validatorToolbox.main_net_rpc)
+    current_epoch = getCurrentEpoch()
     os.system("clear")
     # Print Menu
     print(Style.RESET_ALL)
@@ -106,7 +106,7 @@ def menuTopperRegular() -> None:
 
 
 def menuTopperFull() -> None:
-    current_epoch = blockchain.get_current_epoch(validatorToolbox.main_net_rpc)
+    current_epoch = getCurrentEpoch()
     os.system("clear")
     # Print Menu
     print(Style.RESET_ALL)
@@ -712,6 +712,33 @@ def balanceCheckAny():
     print(f"* Your Validator Wallet Balance on Testnet is: {total_balance_test*0.000000000000000001} Harmony ONE Test Coins")
     printStars()
     input("Press ENTER to continue.")
+
+def getCurrentEpoch():
+    endpoints_count = len(validatorToolbox.rpc_endpoints)
+
+    for i in range(endpoints_count):
+        current_epoch = getCurrentEpochByEndpoint(validatorToolbox.rpc_endpoints[i])
+
+        if current_epoch != -1:
+            return current_epoch
+
+    raise ConnectionError("Couldn't fetch RPC data for current epoch.")
+
+
+def getCurrentEpochByEndpoint(endpoint):
+    current = 0
+    max_tries = validatorToolbox.rpc_endpoints_max_connection_retries
+    current_epoch = -1
+
+    while current < max_tries:
+        try:
+            current_epoch = blockchain.get_current_epoch(endpoint)
+            return current_epoch
+        except Exception:
+            current += 1
+            continue
+
+    return current_epoch
 
 
 def finish_node():


### PR DESCRIPTION
Sometimes the RPC returns "Invalid domain" instead of the current epoch.
The code I propose adds a backup RPC endpoint - api.harmony.one in case the first one fails. 
Also, it retries fetching the data from the RPC 10 times for each of the RPC endpoints in the config file.

![endpoint-error](https://user-images.githubusercontent.com/4356998/138170393-32b9b838-6c47-4a90-8b4c-d62910c6f958.JPG)



