### PR TITLE
Added cli args for stats, harmony.sh ready to rock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argparse >= 1.4.0
 colorama >= 0.4.3
 simple-term-menu >= 1.2.1
 pyhmy == 0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = harmony_toolbox
-version = 1.0.6
+version = 1.0.7
 author = EasyNode.PRO
 author_email = support@easynode.pro
 description = Harmony ONE Validator Node Toolbox and Easy Setup

--- a/src/menu.py
+++ b/src/menu.py
@@ -11,9 +11,8 @@ from toolbox.library import (
     update_text_file,
     first_env_check,
     print_stars,
-    parse_flags
 )
-from toolbox.toolbox import run_full_node, safety_defaults, start_regular_node
+from toolbox.toolbox import run_full_node, safety_defaults, start_regular_node, parse_flags
 
 if __name__ == "__main__":
     loading = True

--- a/src/menu.py
+++ b/src/menu.py
@@ -1,4 +1,4 @@
-import os, subprocess
+import argparse, os, subprocess
 from os import environ
 from colorama import Fore
 from toolbox.config import EnvironmentVariables
@@ -11,6 +11,7 @@ from toolbox.library import (
     update_text_file,
     first_env_check,
     print_stars,
+    parse_flags
 )
 from toolbox.toolbox import run_full_node, safety_defaults, start_regular_node
 
@@ -26,6 +27,8 @@ if __name__ == "__main__":
         print_stars()
         raise SystemExit(0)
     # clear screen, show logo
+    parser = argparse.ArgumentParser(description='Findora Validator Toolbox - Help Menu')
+    parse_flags(parser)
     loader_intro()
     # check for .env file, if none we have a first timer.
     if os.path.exists(EnvironmentVariables.dotenv_file) is None:

--- a/src/multi_stats.py
+++ b/src/multi_stats.py
@@ -4,13 +4,15 @@ import subprocess
 from os import environ
 from ast import literal_eval
 from toolbox.config import EnvironmentVariables
-from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks, get_folders, stats_output_regular
-from toolbox.toolbox import free_space_check, get_rewards_balance, get_db_size, refresh_stats
+from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks
+from toolbox.toolbox import free_space_check, harmony_service_status, get_rewards_balance, get_db_size, refresh_stats
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
 from simple_term_menu import TerminalMenu
 
 load_var_file(EnvironmentVariables.dotenv_file)
+
+user_home = f'{os.path.expanduser("~")}'
 
 if not environ.get("VALIDATOR_WALLET"):
     # ask for wallet, save to env.
@@ -44,11 +46,84 @@ if not environ.get("NETWORK_SWITCH"):
         set_var(EnvironmentVariables.dotenv_file, "RPC_NET", "https://rpc.s0.b.hmny.io")
     subprocess.run("clear")
 
-def run_multistats():
+# Search harmony.conf for the proper port to hit
+def find_port(folder):
+    with open(f'{user_home}/{folder}/harmony.conf') as f:
+        data_file = f.readlines()
+    count = 0
+    for line in data_file:
+        line = line.rstrip()
+        if 'Port =' in line:
+            if count == 3:
+                return line[9:]
+            count += 1
+
+# build list of installs
+def get_folders():
+    folders = {}
+    if os.path.exists(f"{user_home}/harmony/harmony.conf"):
+        port = find_port(f'harmony')
+        folders['harmony'] = port
+        print(f'* Found ~/harmony folder, on port {port}')
+        print_stars()
+    if os.path.exists(f"{user_home}/harmony0/harmony.conf"):
+        port = find_port(f'harmony0')
+        folders['harmony0'] = port
+        print(f'* Found ~/harmony1 folder, on port {port}')
+        print_stars()
+    if os.path.exists(f"{user_home}/harmony1/harmony.conf"):
+        port = find_port(f'harmony1')
+        folders['harmony1'] = port
+        print(f'* Found ~/harmony1 folder, on port {port}')
+        print_stars()
+    if os.path.exists(f"{user_home}/harmony2/harmony.conf"):
+        port = find_port(f'harmony2')
+        folders['harmony2'] = port
+        print(f'* Found ~/harmony2 folder, on port {port}')
+        print_stars()
+    if os.path.exists(f"{user_home}/harmony3/harmony.conf"):
+        port = find_port(f'harmony3')
+        folders['harmony3'] = port
+        print(f'* Found ~/harmony3 folder, on port {port}')
+        print_stars()
+    return folders
+
+def stats_output_regular(folders) -> None:
+    # Get server stats & wallet balances
+    load_1, load_5, load_15 = os.getloadavg()
+    sign_percentage = get_sign_pct()
+    total_balance = get_wallet_balance(environ.get("VALIDATOR_WALLET"))
+    # Print Menu
+    print_stars()
+    print(f'{Fore.GREEN}* harmony-toolbox for {Fore.CYAN}Harmony ONE{Fore.GREEN} Validators by Easy Node   v{EnvironmentVariables.easy_version}{Style.RESET_ALL}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*')
+    print_stars()
+    print(f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Fore.GREEN}\n* Your $ONE balance is:             {Fore.CYAN}{str(round(total_balance, 2))}{Fore.GREEN}\n* Your pending $ONE rewards are:    {Fore.CYAN}{str(round(get_rewards_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET")), 2))}{Fore.GREEN}\n* Server Hostname & IP:             {EnvironmentVariables.server_host_name} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}')
+    for folder in folders:
+        harmony_service_status(folder)
+    print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}{Fore.GREEN}\n* Current user home dir free space: {Fore.CYAN}{free_space_check(EnvironmentVariables.user_home_dir): >6}{Fore.GREEN}')
+    print(f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min")
+    print_stars()
+    remote_shard_0 = [f"{user_home}/{list(folders.items())[0][0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
+    result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    remote_0_data = json.loads(result_shard_0.stdout)
+    print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")
+    print_stars()
+    for folder in folders:
+        current_full_path = f'{EnvironmentVariables.user_home_dir}/{folder}'
+        software_versions = version_checks(current_full_path)
+        print(f'* Results for the current folder: {current_full_path}\n* Current harmony version: {Fore.YELLOW}{software_versions["harmony_version"]}{Fore.GREEN}, has upgrade available: {software_versions["harmony_upgrade"]}\n* Current hmy version: {Fore.YELLOW}{software_versions["hmy_version"]}{Fore.GREEN}, has upgrade available: {software_versions["hmy_upgrade"]}')
+        local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
+        result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        local_data = json.loads(result_local_server.stdout)
+        remote_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=https://api.s{local_data['result']['shard-id']}.t.hmny.io"]
+        result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        remote_data = json.loads(result_remote_server.stdout)
+        print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*   Local Shard 0 Size: {get_db_size(f'{current_full_path}', '0')}\n*   Local Shard {local_data['result']['shard-id']} Size: {get_db_size(f'{current_full_path}', local_data['result']['shard-id'])}")
+        print_stars()
+
+if __name__ == "__main__":
     loader_intro()
     refresh_stats(1)
     folders = get_folders()
     stats_output_regular(folders)
-
-if __name__ == "__main__":
-    run_multistats()

--- a/src/multi_stats.py
+++ b/src/multi_stats.py
@@ -4,15 +4,13 @@ import subprocess
 from os import environ
 from ast import literal_eval
 from toolbox.config import EnvironmentVariables
-from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks
+from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks, get_folders, stats_output_regular
 from toolbox.toolbox import free_space_check, harmony_service_status, get_rewards_balance, get_db_size, refresh_stats
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
 from simple_term_menu import TerminalMenu
 
 load_var_file(EnvironmentVariables.dotenv_file)
-
-user_home = f'{os.path.expanduser("~")}'
 
 if not environ.get("VALIDATOR_WALLET"):
     # ask for wallet, save to env.
@@ -46,81 +44,11 @@ if not environ.get("NETWORK_SWITCH"):
         set_var(EnvironmentVariables.dotenv_file, "RPC_NET", "https://rpc.s0.b.hmny.io")
     subprocess.run("clear")
 
-# Search harmony.conf for the proper port to hit
-def find_port(folder):
-    with open(f'{user_home}/{folder}/harmony.conf') as f:
-        data_file = f.readlines()
-    count = 0
-    for line in data_file:
-        line = line.rstrip()
-        if 'Port =' in line:
-            if count == 3:
-                return line[9:]
-            count += 1
-
-# build list of installs
-def get_folders():
-    folders = {}
-    if os.path.exists(f"{user_home}/harmony/harmony.conf"):
-        port = find_port(f'harmony')
-        folders['harmony'] = port
-        print(f'* Found ~/harmony folder, on port {port}')
-        print_stars()
-    if os.path.exists(f"{user_home}/harmony0/harmony.conf"):
-        port = find_port(f'harmony0')
-        folders['harmony0'] = port
-        print(f'* Found ~/harmony1 folder, on port {port}')
-        print_stars()
-    if os.path.exists(f"{user_home}/harmony1/harmony.conf"):
-        port = find_port(f'harmony1')
-        folders['harmony1'] = port
-        print(f'* Found ~/harmony1 folder, on port {port}')
-        print_stars()
-    if os.path.exists(f"{user_home}/harmony2/harmony.conf"):
-        port = find_port(f'harmony2')
-        folders['harmony2'] = port
-        print(f'* Found ~/harmony2 folder, on port {port}')
-        print_stars()
-    if os.path.exists(f"{user_home}/harmony3/harmony.conf"):
-        port = find_port(f'harmony3')
-        folders['harmony3'] = port
-        print(f'* Found ~/harmony3 folder, on port {port}')
-        print_stars()
-    return folders
-
-def stats_output_regular(folders) -> None:
-    # Get server stats & wallet balances
-    load_1, load_5, load_15 = os.getloadavg()
-    sign_percentage = get_sign_pct()
-    total_balance = get_wallet_balance(environ.get("VALIDATOR_WALLET"))
-    # Print Menu
-    print_stars()
-    print(f'{Fore.GREEN}* harmony-toolbox for {Fore.CYAN}Harmony ONE{Fore.GREEN} Validators by Easy Node   v{EnvironmentVariables.easy_version}{Style.RESET_ALL}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*')
-    print_stars()
-    print(f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Fore.GREEN}\n* Your $ONE balance is:             {Fore.CYAN}{str(round(total_balance, 2))}{Fore.GREEN}\n* Your pending $ONE rewards are:    {Fore.CYAN}{str(round(get_rewards_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET")), 2))}{Fore.GREEN}\n* Server Hostname & IP:             {EnvironmentVariables.server_host_name} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}')
-    for folder in folders:
-        harmony_service_status(folder)
-    print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}{Fore.GREEN}\n* Current user home dir free space: {Fore.CYAN}{free_space_check(EnvironmentVariables.user_home_dir): >6}{Fore.GREEN}')
-    print(f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min")
-    print_stars()
-    remote_shard_0 = [f"{user_home}/{list(folders.items())[0][0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
-    result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    remote_0_data = json.loads(result_shard_0.stdout)
-    print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")
-    print_stars()
-    for folder in folders:
-        current_full_path = f'{EnvironmentVariables.user_home_dir}/{folder}'
-        software_versions = version_checks(current_full_path)
-        print(f'* Results for the current folder: {current_full_path}\n* Current harmony version: {Fore.YELLOW}{software_versions["harmony_version"]}{Fore.GREEN}, has upgrade available: {software_versions["harmony_upgrade"]}\n* Current hmy version: {Fore.YELLOW}{software_versions["hmy_version"]}{Fore.GREEN}, has upgrade available: {software_versions["hmy_upgrade"]}')
-        local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
-        result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        local_data = json.loads(result_local_server.stdout)
-        remote_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=https://api.s{local_data['result']['shard-id']}.t.hmny.io"]
-        result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        remote_data = json.loads(result_remote_server.stdout)
-        print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*   Local Shard 0 Size: {get_db_size(f'{current_full_path}', '0')}\n*   Local Shard {local_data['result']['shard-id']} Size: {get_db_size(f'{current_full_path}', local_data['result']['shard-id'])}")
-        print_stars()
+def run_multistats():
+    loader_intro()
+    refresh_stats(1)
+    folders = get_folders()
+    stats_output_regular(folders)
 
 if __name__ == "__main__":
     loader_intro()

--- a/src/multi_stats.py
+++ b/src/multi_stats.py
@@ -5,7 +5,7 @@ from os import environ
 from ast import literal_eval
 from toolbox.config import EnvironmentVariables
 from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks, get_folders, stats_output_regular
-from toolbox.toolbox import free_space_check, harmony_service_status, get_rewards_balance, get_db_size, refresh_stats
+from toolbox.toolbox import free_space_check, get_rewards_balance, get_db_size, refresh_stats
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
 from simple_term_menu import TerminalMenu
@@ -51,7 +51,4 @@ def run_multistats():
     stats_output_regular(folders)
 
 if __name__ == "__main__":
-    loader_intro()
-    refresh_stats(1)
-    folders = get_folders()
-    stats_output_regular(folders)
+    run_multistats()

--- a/src/multi_stats.py
+++ b/src/multi_stats.py
@@ -88,7 +88,7 @@ def get_folders():
         print_stars()
     return folders
 
-def stats_output_regular(folders) -> None:
+def validator_stats_output(folders) -> None:
     # Get server stats & wallet balances
     load_1, load_5, load_15 = os.getloadavg()
     sign_percentage = get_sign_pct()
@@ -126,4 +126,4 @@ if __name__ == "__main__":
     loader_intro()
     refresh_stats(1)
     folders = get_folders()
-    stats_output_regular(folders)
+    validator_stats_output(folders)

--- a/src/multi_stats.py
+++ b/src/multi_stats.py
@@ -4,7 +4,7 @@ import subprocess
 from os import environ
 from ast import literal_eval
 from toolbox.config import EnvironmentVariables
-from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks
+from toolbox.library import load_var_file, get_sign_pct, get_wallet_balance, print_stars, set_var, loader_intro, ask_yes_no, version_checks, finish_node
 from toolbox.toolbox import free_space_check, harmony_service_status, get_rewards_balance, get_db_size, refresh_stats
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
@@ -127,3 +127,4 @@ if __name__ == "__main__":
     refresh_stats(1)
     folders = get_folders()
     validator_stats_output(folders)
+    finish_node()

--- a/src/toolbox/config.py
+++ b/src/toolbox/config.py
@@ -17,7 +17,7 @@ def get_url(timeout=5) -> str:
 
 
 class EnvironmentVariables:
-    easy_version = "1.0.6"
+    easy_version = "1.0.7"
     server_host_name = socket.gethostname()
     user_home_dir = os.path.expanduser("~")
     dotenv_file = f"{user_home_dir}/.easynode.env"

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -144,44 +144,44 @@ def pull_harmony_update(harmony_dir, bls_key_file, harmony_conf):
 
 # Search harmony.conf for the proper port to hit
 def find_port(folder):
-    with open(f'{EnvironmentVariables.user_home_dir}/{folder}/harmony.conf') as f:
+    with open(f"{EnvironmentVariables.user_home_dir}/{folder}/harmony.conf") as f:
         data_file = f.readlines()
     count = 0
     for line in data_file:
         line = line.rstrip()
-        if 'Port =' in line:
+        if "Port =" in line:
             if count == 3:
                 return line[9:]
             count += 1
-            
+
 
 # build list of installs
 def get_folders():
     folders = {}
     if os.path.exists(f"{EnvironmentVariables.user_home_dir}/harmony/harmony.conf"):
-        port = find_port(f'harmony')
-        folders['harmony'] = port
-        print(f'* Found ~/harmony folder, on port {port}')
+        port = find_port(f"harmony")
+        folders["harmony"] = port
+        print(f"* Found ~/harmony folder, on port {port}")
         print_stars()
     if os.path.exists(f"{EnvironmentVariables.user_home_dir}/harmony0/harmony.conf"):
-        port = find_port(f'harmony0')
-        folders['harmony0'] = port
-        print(f'* Found ~/harmony1 folder, on port {port}')
+        port = find_port(f"harmony0")
+        folders["harmony0"] = port
+        print(f"* Found ~/harmony1 folder, on port {port}")
         print_stars()
     if os.path.exists(f"{EnvironmentVariables.user_home_dir}/harmony1/harmony.conf"):
-        port = find_port(f'harmony1')
-        folders['harmony1'] = port
-        print(f'* Found ~/harmony1 folder, on port {port}')
+        port = find_port(f"harmony1")
+        folders["harmony1"] = port
+        print(f"* Found ~/harmony1 folder, on port {port}")
         print_stars()
     if os.path.exists(f"{EnvironmentVariables.user_home_dir}/harmony2/harmony.conf"):
-        port = find_port(f'harmony2')
-        folders['harmony2'] = port
-        print(f'* Found ~/harmony2 folder, on port {port}')
+        port = find_port(f"harmony2")
+        folders["harmony2"] = port
+        print(f"* Found ~/harmony2 folder, on port {port}")
         print_stars()
     if os.path.exists(f"{EnvironmentVariables.user_home_dir}/harmony3/harmony.conf"):
-        port = find_port(f'harmony3')
-        folders['harmony3'] = port
-        print(f'* Found ~/harmony3 folder, on port {port}')
+        port = find_port(f"harmony3")
+        folders["harmony3"] = port
+        print(f"* Found ~/harmony3 folder, on port {port}")
         print_stars()
     return folders
 
@@ -193,44 +193,96 @@ def validator_stats_output(folders) -> None:
     total_balance = get_wallet_balance(environ.get("VALIDATOR_WALLET"))
     # Print Menu
     print_stars()
-    print(f'{Fore.GREEN}* harmony-toolbox for {Fore.CYAN}Harmony ONE{Fore.GREEN} Validators by Easy Node   v{EnvironmentVariables.easy_version}{Style.RESET_ALL}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*')
+    print(
+        f"{Fore.GREEN}* harmony-toolbox for {Fore.CYAN}Harmony ONE{Fore.GREEN} Validators by Easy Node   v{EnvironmentVariables.easy_version}{Style.RESET_ALL}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*"
+    )
     print_stars()
-    print(f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Fore.GREEN}\n* Your $ONE balance is:             {Fore.CYAN}{str(round(total_balance, 2))}{Fore.GREEN}\n* Your pending $ONE rewards are:    {Fore.CYAN}{str(round(get_rewards_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET")), 2))}{Fore.GREEN}\n* Server Hostname & IP:             {EnvironmentVariables.server_host_name} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}')
+    print(
+        f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Fore.GREEN}\n* Your $ONE balance is:             {Fore.CYAN}{str(round(total_balance, 2))}{Fore.GREEN}\n* Your pending $ONE rewards are:    {Fore.CYAN}{str(round(get_rewards_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET")), 2))}{Fore.GREEN}\n* Server Hostname & IP:             {EnvironmentVariables.server_host_name} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}'
+    )
     for folder in folders:
         harmony_service_status(folder)
-    print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}{Fore.GREEN}\n* Current user home dir free space: {Fore.CYAN}{free_space_check(EnvironmentVariables.user_home_dir): >6}{Fore.GREEN}')
-    print(f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min")
+    print(
+        f"* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}{Fore.GREEN}\n* Current user home dir free space: {Fore.CYAN}{free_space_check(EnvironmentVariables.user_home_dir): >6}{Fore.GREEN}"
+    )
+    print(
+        f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min"
+    )
     print_stars()
-    remote_shard_0 = [f"{EnvironmentVariables.user_home_dir}/{list(folders.items())[0][0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
+    remote_shard_0 = [
+        f"{EnvironmentVariables.user_home_dir}/{list(folders.items())[0][0]}/hmy",
+        "utility",
+        "metadata",
+        f"--node=https://api.s0.t.hmny.io",
+    ]
     result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     remote_0_data = json.loads(result_shard_0.stdout)
-    print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")
+    print(
+        f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}"
+    )
     print_stars()
     for folder in folders:
-        current_full_path = f'{EnvironmentVariables.user_home_dir}/{folder}'
+        current_full_path = f"{EnvironmentVariables.user_home_dir}/{folder}"
         software_versions = version_checks(current_full_path)
-        print(f'* Results for the current folder: {current_full_path}\n* Current harmony version: {Fore.YELLOW}{software_versions["harmony_version"]}{Fore.GREEN}, has upgrade available: {software_versions["harmony_upgrade"]}\n* Current hmy version: {Fore.YELLOW}{software_versions["hmy_version"]}{Fore.GREEN}, has upgrade available: {software_versions["hmy_upgrade"]}')
-        local_server = [f"{EnvironmentVariables.user_home_dir}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
+        print(
+            f'* Results for the current folder: {current_full_path}\n* Current harmony version: {Fore.YELLOW}{software_versions["harmony_version"]}{Fore.GREEN}, has upgrade available: {software_versions["harmony_upgrade"]}\n* Current hmy version: {Fore.YELLOW}{software_versions["hmy_version"]}{Fore.GREEN}, has upgrade available: {software_versions["hmy_upgrade"]}'
+        )
+        local_server = [
+            f"{EnvironmentVariables.user_home_dir}/{folder}/hmy",
+            "utility",
+            "metadata",
+            f"--node=http://localhost:{folders[folder]}",
+        ]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data = json.loads(result_local_server.stdout)
-        remote_server = [f"{EnvironmentVariables.user_home_dir}/{folder}/hmy", "utility", "metadata", f"--node=https://api.s{local_data['result']['shard-id']}.t.hmny.io"]
+        remote_server = [
+            f"{EnvironmentVariables.user_home_dir}/{folder}/hmy",
+            "utility",
+            "metadata",
+            f"--node=https://api.s{local_data['result']['shard-id']}.t.hmny.io",
+        ]
         result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         remote_data = json.loads(result_remote_server.stdout)
-        print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*   Local Shard 0 Size: {get_db_size(f'{current_full_path}', '0')}\n*   Local Shard {local_data['result']['shard-id']} Size: {get_db_size(f'{current_full_path}', local_data['result']['shard-id'])}")
+        print(
+            f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}"
+        )
+        print(
+            f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*   Local Shard 0 Size: {get_db_size(f'{current_full_path}', '0')}\n*   Local Shard {local_data['result']['shard-id']} Size: {get_db_size(f'{current_full_path}', local_data['result']['shard-id'])}"
+        )
         print_stars()
-        
 
-def harmony_service_status(service = "harmony") -> None:
+
+def harmony_service_status(service="harmony") -> None:
     status = subprocess.call(["systemctl", "is-active", "--quiet", service])
     if status == 0:
         if service == "harmony":
-            print(f"* {service} Service is:               " + Fore.BLACK + Back.GREEN + "   Online  " + Style.RESET_ALL + Fore.GREEN)
+            print(
+                f"* {service} Service is:               "
+                + Fore.BLACK
+                + Back.GREEN
+                + "   Online  "
+                + Style.RESET_ALL
+                + Fore.GREEN
+            )
         else:
-            print(f"* {service} Service is:              " + Fore.BLACK + Back.GREEN + "   Online  " + Style.RESET_ALL + Fore.GREEN)
+            print(
+                f"* {service} Service is:              "
+                + Fore.BLACK
+                + Back.GREEN
+                + "   Online  "
+                + Style.RESET_ALL
+                + Fore.GREEN
+            )
     else:
-        print(f"* {service} Service is:               " + Fore.WHITE + Back.RED + "  *** Offline *** " + Style.RESET_ALL + Fore.GREEN)
-        
+        print(
+            f"* {service} Service is:               "
+            + Fore.WHITE
+            + Back.RED
+            + "  *** Offline *** "
+            + Style.RESET_ALL
+            + Fore.GREEN
+        )
+
 
 def set_wallet_env():
     if environ.get("NODE_WALLET") == "true":
@@ -1170,9 +1222,9 @@ def finish_node():
     print(
         "* Thanks for using Easy Node Toolbox - Making everything Easy Mode!"
         + "\n*\n* We serve up free tools and guides for validators every day."
-        + "\n*\n* Check our guides out at https://guides.easynode.pro\n*\n"
-        + "* Please consider joining our discord & supporting us one time or monthly"
-        + " at https://discord.gg/Rcz5T6D9CV today!\n*\n* Goodbye!"
+        + "\n*\n* Check our guides out at https://docs.easynode.pro\n*\n"
+        + "* Please consider joining our discord & supporting us one time or monthly for our tools"
+        + " and guides at https://bit.ly/easynodediscord today!\n*\n* Goodbye!"
     )
     print_stars()
     raise SystemExit(0)

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from simple_term_menu import TerminalMenu
 from colorama import Fore, Style, Back
 from pathlib import Path
-from pyhmy import account, staking
+from pyhmy import account, staking, validators, numbers
 from json import load, dump
 from toolbox.config import EnvironmentVariables
 from collections import namedtuple

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -186,7 +186,7 @@ def get_folders():
     return folders
 
 
-def stats_output_regular(folders) -> None:
+def validator_stats_output(folders) -> None:
     # Get server stats & wallet balances
     load_1, load_5, load_15 = os.getloadavg()
     sign_percentage = get_sign_pct()

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -248,6 +248,13 @@ def set_wallet_env():
             return validator_wallet
 
 
+def get_db_size(harmony_dir, our_shard) -> str:
+    harmony_db_size = subprocess.getoutput(f"du -h {harmony_dir}/harmony_db_{our_shard}")
+    harmony_db_size = harmony_db_size.rstrip("\t")
+    countTrim = len(EnvironmentVariables.harmony_dir) + 13
+    return harmony_db_size[:-countTrim]
+
+
 def recovery_type():
     subprocess.run("clear")
     set_var(EnvironmentVariables.dotenv_file, "NODE_WALLET", "true")

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -507,10 +507,11 @@ def current_price():
 
 
 def get_wallet_balance(wallet_addr):
+    config = EnvironmentVariables()
     endpoints_count = len(EnvironmentVariables.rpc_endpoints)
 
     for i in range(endpoints_count):
-        wallet_balance = get_wallet_balance_by_endpoint(EnvironmentVariables.rpc_endpoints[i], wallet_addr)
+        wallet_balance = get_wallet_balance_by_endpoint(config.working_rpc_endpoint, wallet_addr)
         if wallet_balance is not None and wallet_balance > 0:
             return wallet_balance
 

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -510,10 +510,8 @@ def get_wallet_balance(wallet_addr):
     config = EnvironmentVariables()
     rpc_endpoint = config.working_rpc_endpoint
     wallet_balance = get_wallet_balance_by_endpoint(rpc_endpoint, wallet_addr)
-    if wallet_balance is not None and wallet_balance > 0:
+    if wallet_balance is not None:
         return wallet_balance
-
-    raise ConnectionError("Couldn't fetch RPC data for current epoch.")
 
 
 def get_wallet_balance_by_endpoint(endpoint, wallet_addr):

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from simple_term_menu import TerminalMenu
 from colorama import Fore, Style, Back
 from pathlib import Path
-from pyhmy import account, staking, validators, numbers
+from pyhmy import account, staking, validator, numbers
 from json import load, dump
 from toolbox.config import EnvironmentVariables
 from collections import namedtuple

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -1223,8 +1223,8 @@ def finish_node():
         "* Thanks for using Easy Node Toolbox - Making everything Easy Mode!"
         + "\n*\n* We serve up free tools and guides for validators every day."
         + "\n*\n* Check our guides out at https://docs.easynode.pro\n*\n"
-        + "* Please consider joining our discord & supporting us one time or monthly for our tools"
-        + " and guides at https://bit.ly/easynodediscord today!\n*\n* Goodbye!"
+        + "* Please consider joining our discord & supporting us one time or monthly\n* for our"
+        + " tools and guides at https://bit.ly/easynodediscord today!\n*\n* Goodbye!"
     )
     print_stars()
     raise SystemExit(0)

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pyhmy import validator, account, staking, numbers
 from json import load, dump
 from toolbox.config import EnvironmentVariables
+from multi_stats import run_multistats
 from collections import namedtuple
 from datetime import datetime
 from subprocess import PIPE, run
@@ -68,6 +69,7 @@ def parse_flags(parser):
     print(Fore.RESET)
     
     if args.stats:
+        run_multistats()
         
 
 

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -508,12 +508,10 @@ def current_price():
 
 def get_wallet_balance(wallet_addr):
     config = EnvironmentVariables()
-    endpoints_count = len(EnvironmentVariables.rpc_endpoints)
-
-    for i in range(endpoints_count):
-        wallet_balance = get_wallet_balance_by_endpoint(config.working_rpc_endpoint, wallet_addr)
-        if wallet_balance is not None and wallet_balance > 0:
-            return wallet_balance
+    rpc_endpoint = config.working_rpc_endpoint
+    wallet_balance = get_wallet_balance_by_endpoint(rpc_endpoint, wallet_addr)
+    if wallet_balance is not None and wallet_balance > 0:
+        return wallet_balance
 
     raise ConnectionError("Couldn't fetch RPC data for current epoch.")
 

--- a/src/toolbox/library.py
+++ b/src/toolbox/library.py
@@ -1,13 +1,12 @@
-import psutil, platform, dotenv, time, os, subprocess, requests, pyhmy, shutil, hashlib, re, json, subprocess
+import psutil, platform, dotenv, os, subprocess, requests, pyhmy, shutil, hashlib, re, json, subprocess
 from os import environ
 from dotenv import load_dotenv
 from simple_term_menu import TerminalMenu
 from colorama import Fore, Style, Back
 from pathlib import Path
-from pyhmy import validator, account, staking, numbers
+from pyhmy import account, staking
 from json import load, dump
 from toolbox.config import EnvironmentVariables
-from multi_stats import run_multistats
 from collections import namedtuple
 from datetime import datetime
 from subprocess import PIPE, run
@@ -52,25 +51,6 @@ def set_var(env_file, key_name, update_name):
     dotenv.set_key(env_file, key_name, update_name)
     load_var_file(env_file)
     return
-
-
-def parse_flags(parser):
-    # Add the arguments
-    parser.add_argument(
-        "-s",
-        "--stats",
-        action="store_true",
-        help="Run your stats if Harmony is installed and running.",
-    )
-    
-    args = parser.parse_args()
-    
-    subprocess.run("clear")
-    print(Fore.RESET)
-    
-    if args.stats:
-        run_multistats()
-        
 
 
 # loader intro splash screen

--- a/src/toolbox/toolbox.py
+++ b/src/toolbox/toolbox.py
@@ -57,7 +57,7 @@ def parse_flags(parser):
 
     if args.stats:
         run_multistats()
-        raise SystemExit(0)
+        finish_node()
 
 
 def run_multistats():

--- a/src/toolbox/toolbox.py
+++ b/src/toolbox/toolbox.py
@@ -33,18 +33,49 @@ from toolbox.library import (
     finish_node,
     pull_harmony_update,
     version_checks,
-    harmony_service_status
+    harmony_service_status,
+    loader_intro,
+    get_folders,
+    stats_output_regular
 )
+
+
+def parse_flags(parser):
+    # Add the arguments
+    parser.add_argument(
+        "-s",
+        "--stats",
+        action="store_true",
+        help="Run your stats if Harmony is installed and running.",
+    )
+
+    args = parser.parse_args()
+
+    subprocess.run("clear")
+    print(Fore.RESET)
+
+    if args.stats:
+        run_multistats()
+
+
+def run_multistats():
+    loader_intro()
+    refresh_stats(1)
+    folders = get_folders()
+    stats_output_regular(folders)
+
 
 def collect_rewards(networkCall):
     os.system(
         f"{networkCall} staking collect-rewards --delegator-addr {environ.get('VALIDATOR_WALLET')} --gas-price 100 {environ.get('PASS_SWITCH')}"
     )
 
+
 def send_rewards(networkCall, sendAmount, rewards_wallet):
     os.system(
         f"{networkCall} transfer --amount {sendAmount} --from {environ.get('VALIDATOR_WALLET')} --from-shard 0 --to {rewards_wallet} --to-shard 0 --gas-price 100 {environ.get('PASS_SWITCH')}"
     )
+
 
 def rewards_collector(rewards_wallet, validator_wallet, rpc) -> None:
     print("* Harmony ONE Rewards Collection")
@@ -56,10 +87,7 @@ def rewards_collector(rewards_wallet, validator_wallet, rpc) -> None:
         collect_rewards(EnvironmentVariables.hmy_app)
         print_stars()
         print(
-            Fore.GREEN
-            + f"* mainnet rewards for {validator_wallet} have been collected."
-            + Style.RESET_ALL
-+ Fore.GREEN
+            Fore.GREEN + f"* mainnet rewards for {validator_wallet} have been collected." + Style.RESET_ALL + Fore.GREEN
         )
         print_stars()
     else:
@@ -78,6 +106,7 @@ def rewards_collector(rewards_wallet, validator_wallet, rpc) -> None:
             send_rewards(EnvironmentVariables.hmy_app, suggested_send, rewards_wallet)
         return
 
+
 def menu_topper_regular(software_versions) -> None:
     # Get stats & balances
     try:
@@ -86,44 +115,76 @@ def menu_topper_regular(software_versions) -> None:
         total_balance = get_wallet_balance(environ.get("VALIDATOR_WALLET"))
         remote_data_shard_0, local_data_shard, remote_data_shard = menu_validator_stats()
     except (ValueError, KeyError, TypeError) as e:
-        print(f'* Error fetching data: {e}')
+        print(f"* Error fetching data: {e}")
     subprocess.run("clear")
     # Print Menu
     print_stars()
-    print(f'{Fore.GREEN}* Validator Toolbox for {Fore.CYAN}Harmony ONE{Fore.GREEN} Validators by Easy Node   v{environ.get("EASY_VERSION")}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*')
+    print(
+        f'{Fore.GREEN}* Validator Toolbox for {Fore.CYAN}Harmony ONE{Fore.GREEN} Validators by Easy Node   v{environ.get("EASY_VERSION")}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*'
+    )
     print_stars()
-    print(f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Fore.GREEN}\n* Your $ONE balance is:             {Fore.CYAN}{str(round(total_balance, 2))}{Fore.GREEN}\n* Your pending $ONE rewards are:    {Fore.CYAN}{str(round(get_rewards_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET")), 2))}{Fore.GREEN}\n* Server Hostname & IP:             {Fore.BLUE}{EnvironmentVariables.server_host_name}{Fore.GREEN} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}')
+    print(
+        f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Fore.GREEN}\n* Your $ONE balance is:             {Fore.CYAN}{str(round(total_balance, 2))}{Fore.GREEN}\n* Your pending $ONE rewards are:    {Fore.CYAN}{str(round(get_rewards_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET")), 2))}{Fore.GREEN}\n* Server Hostname & IP:             {Fore.BLUE}{EnvironmentVariables.server_host_name}{Fore.GREEN} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}'
+    )
     harmony_service_status()
-    print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}{Fore.GREEN}\n* Current disk space free: {Fore.CYAN}{free_space_check(EnvironmentVariables.harmony_dir): >6}{Fore.GREEN}\n* Current harmony version: {Fore.YELLOW}{software_versions["harmony_version"]}{Fore.GREEN}, has upgrade available: {software_versions["harmony_upgrade"]}\n* Current hmy version: {Fore.YELLOW}{software_versions["hmy_version"]}{Fore.GREEN}, has upgrade available: {software_versions["hmy_upgrade"]}')
+    print(
+        f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}{Fore.GREEN}\n* Current disk space free: {Fore.CYAN}{free_space_check(EnvironmentVariables.harmony_dir): >6}{Fore.GREEN}\n* Current harmony version: {Fore.YELLOW}{software_versions["harmony_version"]}{Fore.GREEN}, has upgrade available: {software_versions["harmony_upgrade"]}\n* Current hmy version: {Fore.YELLOW}{software_versions["hmy_version"]}{Fore.GREEN}, has upgrade available: {software_versions["hmy_upgrade"]}'
+    )
     print_stars()
     if environ.get("SHARD") != "0":
-        print(f"* Note: Running on shard {environ.get('SHARD')}, Shard 0 is no longer needed locally and should be under 300MB\n* Remote Shard 0 Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}, Local Shard 0 Size: {get_db_size(EnvironmentVariables.harmony_dir, '0')}")
-        print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard['result']['shard-chain-header']['number'])}")
-        print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {get_db_size(EnvironmentVariables.harmony_dir, environ.get('SHARD'))}")
+        print(
+            f"* Note: Running on shard {environ.get('SHARD')}, Shard 0 is no longer needed locally and should be under 300MB\n* Remote Shard 0 Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}, Local Shard 0 Size: {get_db_size(EnvironmentVariables.harmony_dir, '0')}"
+        )
+        print(
+            f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard['result']['shard-chain-header']['number'])}"
+        )
+        print(
+            f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {get_db_size(EnvironmentVariables.harmony_dir, environ.get('SHARD'))}"
+        )
     if environ.get("SHARD") == "0":
-        print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}")
-        print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}")
-    print(f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min")
+        print(
+            f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}"
+        )
+        print(
+            f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}"
+        )
+    print(
+        f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min"
+    )
     print_stars()
+
 
 def menu_topper_full() -> None:
     try:
         load_1, load_5, load_15 = os.getloadavg()
         remote_data_shard_0, local_data_shard, remote_data_shard = menu_validator_stats()
     except (ValueError, KeyError, TypeError) as e:
-        print(f'* Error fetching data: {e}')
+        print(f"* Error fetching data: {e}")
     subprocess.run("clear")
     # Print Menu
     print_stars()
-    print(f'{Fore.GREEN}* Validator Toolbox for Harmony ONE Validators by Easy Node   v{environ.get("EASY_VERSION")}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*')
+    print(
+        f'{Fore.GREEN}* Validator Toolbox for Harmony ONE Validators by Easy Node   v{environ.get("EASY_VERSION")}{Fore.WHITE}   https://easynode.pro {Fore.GREEN}*'
+    )
     print_stars()
-    print(f'* Server Hostname & IP:             {Fore.BLUE}{EnvironmentVariables.server_host_name}{Fore.GREEN} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}')
+    print(
+        f"* Server Hostname & IP:             {Fore.BLUE}{EnvironmentVariables.server_host_name}{Fore.GREEN} - {Fore.YELLOW}{EnvironmentVariables.external_ip}{Fore.GREEN}"
+    )
     harmony_service_status()
-    print(f'* Current disk space free: {Fore.CYAN}{free_space_check(EnvironmentVariables.harmony_dir): >6}{Fore.GREEN}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Fore.GREEN}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Fore.GREEN}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
-    print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}")
-    print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}")
-    print(f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min")
+    print(
+        f'* Current disk space free: {Fore.CYAN}{free_space_check(EnvironmentVariables.harmony_dir): >6}{Fore.GREEN}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Fore.GREEN}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Fore.GREEN}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}'
+    )
+    print(
+        f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}"
+    )
+    print(
+        f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}"
+    )
+    print(
+        f"* CPU Load Averages: {round(load_1, 2)} over 1 min, {round(load_5, 2)} over 5 min, {round(load_15, 2)} over 15 min"
+    )
     print_stars()
+
 
 def menu_regular(software_versions) -> None:
     menu_topper_regular(software_versions)
@@ -136,6 +197,7 @@ def menu_regular(software_versions) -> None:
         if x:
             print(x)
 
+
 def menu_full() -> None:
     menu_topper_full()
     for x in return_txt(EnvironmentVariables.main_menu_full):
@@ -146,6 +208,7 @@ def menu_full() -> None:
             pass
         if x:
             print(x)
+
 
 def get_wallet_json(wallet: str) -> str:
     test_or_main = environ.get("NETWORK")
@@ -169,6 +232,7 @@ def get_wallet_json(wallet: str) -> str:
         return
     return json_response
 
+
 def tmi_server_info() -> None:
     validator_wallet = environ.get("VALIDATOR_WALLET")
     json_response = get_wallet_json(validator_wallet)
@@ -176,6 +240,7 @@ def tmi_server_info() -> None:
         print(key, ":", value)
     print_stars()
     input("Press ENTER to return to the main menu.")
+
 
 def set_rewards_wallet() -> None:
     rewards_wallet = environ.get("REWARDS_WALLET")
@@ -212,6 +277,7 @@ def set_rewards_wallet() -> None:
                 return
     return
 
+
 def set_gas_reserve() -> None:
     gas_reserve = environ.get("GAS_RESERVE")
     question = ask_yes_no(
@@ -221,20 +287,25 @@ def set_gas_reserve() -> None:
         ask_reserve_total()
     return
 
+
 def ask_reserve_total() -> None:
     reserve_total = input("* How much $ONE would you like to keep reserved for fees? ")
     set_reserve_total(reserve_total)
     return
 
+
 def set_reserve_total(reserve_total):
     set_var(EnvironmentVariables.dotenv_file, "GAS_RESERVE", reserve_total)
+
 
 def drive_check() -> None:
     server_drive_check(EnvironmentVariables.dotenv_file, EnvironmentVariables.harmony_dir)
     return
 
+
 def run_check_balance() -> None:
     menu_check_balance(EnvironmentVariables.rpc_endpoints, environ.get("VALIDATOR_WALLET"))
+
 
 def run_full_node() -> None:
     menu_options = {
@@ -279,6 +350,7 @@ def run_full_node() -> None:
         subprocess.run("clear")
         menu_options[option]()
 
+
 def bingo_checker():
     os.system(f"grep BINGO {EnvironmentVariables.harmony_dir}/latest/zerolog-harmony.log | tail -10")
     print_stars()
@@ -286,61 +358,90 @@ def bingo_checker():
     print_stars()
     input()
 
+
 def run_rewards_collector() -> None:
-    rewards_collector(environ.get("REWARDS_WALLET"), environ.get('VALIDATOR_WALLET'), EnvironmentVariables.rpc_endpoints)
+    rewards_collector(
+        environ.get("REWARDS_WALLET"), environ.get("VALIDATOR_WALLET"), EnvironmentVariables.rpc_endpoints
+    )
     return
 
+
 def safety_defaults() -> None:
-    if environ.get("GAS_RESERVE") is None: set_var(EnvironmentVariables.dotenv_file, "GAS_RESERVE", "5")
-    if environ.get("REFRESH_TIME") is None: set_var(EnvironmentVariables.dotenv_file, "REFRESH_TIME", "30")
-    if environ.get("REFRESH_OPTION") is None: set_var(EnvironmentVariables.dotenv_file, "REFRESH_OPTION", "True")
-    if environ.get("HARMONY_FOLDER") is None: 
-        if os.path.isdir(f'{EnvironmentVariables.user_home_dir}/harmony'):
-            set_var(EnvironmentVariables.dotenv_file, "HARMONY_FOLDER", f'{EnvironmentVariables.user_home_dir}/harmony')
-        elif os.path.exists(f'{EnvironmentVariables.user_home_dir}/harmony'):
+    if environ.get("GAS_RESERVE") is None:
+        set_var(EnvironmentVariables.dotenv_file, "GAS_RESERVE", "5")
+    if environ.get("REFRESH_TIME") is None:
+        set_var(EnvironmentVariables.dotenv_file, "REFRESH_TIME", "30")
+    if environ.get("REFRESH_OPTION") is None:
+        set_var(EnvironmentVariables.dotenv_file, "REFRESH_OPTION", "True")
+    if environ.get("HARMONY_FOLDER") is None:
+        if os.path.isdir(f"{EnvironmentVariables.user_home_dir}/harmony"):
+            set_var(EnvironmentVariables.dotenv_file, "HARMONY_FOLDER", f"{EnvironmentVariables.user_home_dir}/harmony")
+        elif os.path.exists(f"{EnvironmentVariables.user_home_dir}/harmony"):
             try:
-                subprocess.run(f'{EnvironmentVariables.user_home_dir}/harmony --version', check=True)
-                set_var(set_var(EnvironmentVariables.dotenv_file, "HARMONY_FOLDER", f'{EnvironmentVariables.user_home_dir}'))
+                subprocess.run(f"{EnvironmentVariables.user_home_dir}/harmony --version", check=True)
+                set_var(
+                    set_var(EnvironmentVariables.dotenv_file, "HARMONY_FOLDER", f"{EnvironmentVariables.user_home_dir}")
+                )
             except subprocess.CalledProcessError as e:
-                print('* Harmony not found, contact Easy Node for custom configs.')
+                print("* Harmony not found, contact Easy Node for custom configs.")
                 raise SystemExit(0)
         else:
-            print('* Harmony not found, contact Easy Node for custom configs.')
+            print("* Harmony not found, contact Easy Node for custom configs.")
             raise SystemExit(0)
     set_var(EnvironmentVariables.dotenv_file, "EASY_VERSION", EnvironmentVariables.easy_version)
 
+
 def refresh_toggle() -> None:
     if environ.get("REFRESH_OPTION") == "True":
-        answer = ask_yes_no(f'* Refresh is currently enabled. Would you like to disable it? (Y/N) ')
+        answer = ask_yes_no(f"* Refresh is currently enabled. Would you like to disable it? (Y/N) ")
         if answer:
             set_var(EnvironmentVariables.dotenv_file, "REFRESH_OPTION", "False")
         else:
-            answer = ask_yes_no(f'* Your current refresh time is {str(environ.get("REFRESH_TIME"))} seconds. Would you like to change the delay? (Y/N) ')
+            answer = ask_yes_no(
+                f'* Your current refresh time is {str(environ.get("REFRESH_TIME"))} seconds. Would you like to change the delay? (Y/N) '
+            )
             if answer:
-                delay_time = timedInteger("* Enter the number of seconds to wait before auto-refreshing: ", timeout=-1, resetOnInput=True, allowNegative=False)
+                delay_time = timedInteger(
+                    "* Enter the number of seconds to wait before auto-refreshing: ",
+                    timeout=-1,
+                    resetOnInput=True,
+                    allowNegative=False,
+                )
                 set_var(EnvironmentVariables.dotenv_file, "REFRESH_TIME", str(delay_time[0]))
     else:
-        answer = ask_yes_no(f'* Refresh is currently disabled. Would you like to enable it? (Y/N) ')
+        answer = ask_yes_no(f"* Refresh is currently disabled. Would you like to enable it? (Y/N) ")
         if answer:
             set_var(EnvironmentVariables.dotenv_file, "REFRESH_OPTION", "True")
-        answer = ask_yes_no(f'* Your current refresh time is {str(environ.get("REFRESH_TIME"))} seconds. Would you like to change the delay? (Y/N) ')
+        answer = ask_yes_no(
+            f'* Your current refresh time is {str(environ.get("REFRESH_TIME"))} seconds. Would you like to change the delay? (Y/N) '
+        )
         if answer:
-            delay_time = timedInteger("* Enter the number of seconds to wait before auto-refreshing: ", timeout=-1, resetOnInput=True, allowNegative=False)
+            delay_time = timedInteger(
+                "* Enter the number of seconds to wait before auto-refreshing: ",
+                timeout=-1,
+                resetOnInput=True,
+                allowNegative=False,
+            )
             set_var(EnvironmentVariables.dotenv_file, "REFRESH_TIME", str(delay_time[0]))
     load_var_file(EnvironmentVariables.dotenv_file)
     return
 
+
 def refresh_status_option():
     if environ.get("REFRESH_OPTION") == "True":
-        print(f"*  20 - Disable auto-refresh      - Disable Refresh or Change Delay Timer: {str(environ.get('REFRESH_TIME'))} seconds")
+        print(
+            f"*  20 - Disable auto-refresh      - Disable Refresh or Change Delay Timer: {str(environ.get('REFRESH_TIME'))} seconds"
+        )
     else:
         print(f"*  20 - Enable Auto refresh       - Enable Refresh Timeout")
+
 
 def start_regular_node() -> None:
     # Check online versions of harmony & hmy and compare to our local copy.
     refresh_stats(1)
     software_versions = version_checks(environ.get("HARMONY_FOLDER"))
     run_regular_node(software_versions)
+
 
 def run_regular_node(software_versions) -> None:
     menu_options = {
@@ -379,7 +480,12 @@ def run_regular_node(software_versions) -> None:
         if environ.get("REFRESH_OPTION") == "True":
             try:
                 # run timed input
-                option, timedOut = timedInteger(f"* Auto refresh enabled, Enter your menu choice: ", timeout=int(environ.get("REFRESH_TIME")), resetOnInput=True, allowNegative=False)
+                option, timedOut = timedInteger(
+                    f"* Auto refresh enabled, Enter your menu choice: ",
+                    timeout=int(environ.get("REFRESH_TIME")),
+                    resetOnInput=True,
+                    allowNegative=False,
+                )
                 if timedOut:
                     start_regular_node()
                 else:
@@ -389,13 +495,18 @@ def run_regular_node(software_versions) -> None:
                     if option != 1:
                         start_regular_node()
             except KeyError:
-                print(f'* Bad option, try again. Press enter to continue.')
+                print(f"* Bad option, try again. Press enter to continue.")
                 print_stars()
                 input()
                 start_regular_node()
         else:
             try:
-                option, timedOut = timedInteger("* Auto refresh disabled, Enter your menu choice: ", timeout=-1, resetOnInput=True, allowNegative=False)
+                option, timedOut = timedInteger(
+                    "* Auto refresh disabled, Enter your menu choice: ",
+                    timeout=-1,
+                    resetOnInput=True,
+                    allowNegative=False,
+                )
                 subprocess.run("clear")
                 print_stars()
                 menu_options[option]()
@@ -407,18 +518,25 @@ def run_regular_node(software_versions) -> None:
                 input()
                 start_regular_node()
 
+
 def service_menu_option() -> None:
     status = os.system("systemctl is-active --quiet harmony")
     if status == 0:
-        print(f'*   8 - {Fore.RED}Stop Harmony Service      {Fore.GREEN}- {Fore.YELLOW}{Back.RED}WARNING: You will miss blocks while stopped!   {Style.RESET_ALL}{Fore.GREEN}')
-        print(f'*   9 - Restart Harmony Service   - {Back.RED}{Fore.YELLOW}WARNING: You will miss blocks during a restart!{Style.RESET_ALL}{Fore.GREEN}')
+        print(
+            f"*   8 - {Fore.RED}Stop Harmony Service      {Fore.GREEN}- {Fore.YELLOW}{Back.RED}WARNING: You will miss blocks while stopped!   {Style.RESET_ALL}{Fore.GREEN}"
+        )
+        print(
+            f"*   9 - Restart Harmony Service   - {Back.RED}{Fore.YELLOW}WARNING: You will miss blocks during a restart!{Style.RESET_ALL}{Fore.GREEN}"
+        )
     else:
-        print(f'*   8 - Start Harmony Service')
+        print(f"*   8 - Start Harmony Service")
+
 
 def make_backup_dir() -> str:
     folder_name = f'{EnvironmentVariables.harmony_dir}/harmony_backup/{datetime.now().strftime("%Y%m%d%H%M")}'
     os.system(f"mkdir -p {folder_name}")
     return folder_name
+
 
 def hmy_cli_upgrade():
     question = ask_yes_no(
@@ -436,17 +554,22 @@ def hmy_cli_upgrade():
         set_var(EnvironmentVariables.dotenv_file, "HMY_UPGRADE_AVAILABLE", "False")
         input("* Update completed, press ENTER to return to the main menu. ")
 
+
 def update_harmony_app():
     os.chdir(f"{EnvironmentVariables.harmony_dir}")
     print_stars()
     print("Currently installed version: ")
     os.system("./harmony -V")
     folder_name = make_backup_dir()
-    os.system(f"cp {EnvironmentVariables.harmony_dir}/harmony {EnvironmentVariables.harmony_dir}/harmony.conf {folder_name}")
+    os.system(
+        f"cp {EnvironmentVariables.harmony_dir}/harmony {EnvironmentVariables.harmony_dir}/harmony.conf {folder_name}"
+    )
     print_stars()
     print("Downloading current harmony binary file from harmony.one: ")
     print_stars()
-    pull_harmony_update(EnvironmentVariables.harmony_dir, EnvironmentVariables.bls_key_file, EnvironmentVariables.harmony_conf)
+    pull_harmony_update(
+        EnvironmentVariables.harmony_dir, EnvironmentVariables.bls_key_file, EnvironmentVariables.harmony_conf
+    )
     print_stars()
     print("Updated version: ")
     os.system("./harmony -V")
@@ -478,6 +601,7 @@ def update_harmony_app():
     set_var(EnvironmentVariables.dotenv_file, "HARMONY_UPGRADE_AVAILABLE", "False")
     time.sleep(10)
 
+
 def menu_validator_stats():
     load_var_file(EnvironmentVariables.dotenv_file)
     remote_shard_0 = [
@@ -490,14 +614,16 @@ def menu_validator_stats():
         result_remote_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         remote_data_shard_0 = json.loads(result_remote_shard_0.stdout)
     except (ValueError, KeyError, TypeError) as e:
-        print(f'* Remote Shard 0 Offline, Error {e}')
+        print(f"* Remote Shard 0 Offline, Error {e}")
     try:
         local_shard = [f"{EnvironmentVariables.hmy_app}", "blockchain", "latest-headers"]
         result_local_shard = run(local_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data_shard = json.loads(result_local_shard.stdout)
     except (ValueError, KeyError, TypeError) as e:
-        print(f'* Local Server Offline, restart your service or troubleshoot the issue by running the following in your ~/harmony directory:\n* ./harmony -c harmony.conf, Error: {e}')
-            
+        print(
+            f"* Local Server Offline, restart your service or troubleshoot the issue by running the following in your ~/harmony directory:\n* ./harmony -c harmony.conf, Error: {e}"
+        )
+
     if environ.get("SHARD") != "0":
         remote_shard = [
             f"{EnvironmentVariables.hmy_app}",
@@ -511,23 +637,26 @@ def menu_validator_stats():
             return remote_data_shard_0, local_data_shard, remote_data_shard
         except (ValueError, KeyError, TypeError):
             return
-        
+
     return remote_data_shard_0, local_data_shard, None
+
 
 def refresh_stats(clear=0) -> str:
     print(Fore.GREEN)
     if clear == 0:
         subprocess.run("clear")
     print_stars()
-    print(f'* Getting the latest local & blockchain information now, one moment while we load...')
+    print(f"* Getting the latest local & blockchain information now, one moment while we load...")
     print_stars()
     return
+
 
 def get_db_size(harmony_dir, our_shard) -> str:
     harmony_db_size = subprocess.getoutput(f"du -h {harmony_dir}/harmony_db_{our_shard}")
     harmony_db_size = harmony_db_size.rstrip("\t")
     countTrim = len(EnvironmentVariables.harmony_dir) + 13
     return harmony_db_size[:-countTrim]
+
 
 def shard_stats(our_shard) -> str:
     our_uptime = subprocess.getoutput("uptime")
@@ -552,6 +681,7 @@ def shard_stats(our_shard) -> str:
         """
         )
 
+
 def harmony_binary_upgrade():
     question = ask_yes_no(
         Fore.RED
@@ -561,6 +691,7 @@ def harmony_binary_upgrade():
     )
     if question:
         update_harmony_app()
+
 
 def menu_service_stop_start() -> str:
     status = os.system("systemctl is-active --quiet harmony")
@@ -586,10 +717,11 @@ def menu_service_stop_start() -> str:
                 + Fore.RED
                 + "YOU ARE MISSING BLOCKS ON THIS NODE."
                 + Style.RESET_ALL
-+ Fore.GREEN
+                + Fore.GREEN
             )
             print()
             input("* Press ENTER to return to the main menu.")
+
 
 def menu_service_restart() -> str:
     question = ask_yes_no(
@@ -605,6 +737,7 @@ def menu_service_restart() -> str:
         print("* The Harmony Service Has Been Restarted")
         input("* Press ENTER to return to the main menu.")
 
+
 def menu_active_bls() -> str:
     validator_wallet = environ.get("VALIDATOR_WALLET")
     json_response = get_wallet_json(validator_wallet)
@@ -616,6 +749,7 @@ def menu_active_bls() -> str:
     print_stars()
     input()
 
+
 # is this used?
 def is_float(value):
     try:
@@ -623,6 +757,7 @@ def is_float(value):
         return True
     except ValueError:
         return False
+
 
 def menu_check_balance(rpc, validator_wallet) -> None:
     if environ.get("NODE_TYPE") == "regular":
@@ -649,6 +784,7 @@ def menu_check_balance(rpc, validator_wallet) -> None:
             else:
                 i = 1
 
+
 def balanceCheckAny():
     check_wallet = input(
         "* Type the address of the Harmony ONE Wallet you would like to check.\n"
@@ -663,6 +799,7 @@ def balanceCheckAny():
     print_stars()
     input("* Press ENTER to continue.")
 
+
 def get_current_epoch():
     if environ.get("NETWORK") == "mainnet":
         endpoints_count = len(EnvironmentVariables.rpc_endpoints)
@@ -676,6 +813,7 @@ def get_current_epoch():
             return current_epoch
     current_epoch = 0
     return current_epoch
+
 
 def get_current_epochByEndpoint(endpoint):
     current = 0

--- a/src/toolbox/toolbox.py
+++ b/src/toolbox/toolbox.py
@@ -32,7 +32,8 @@ from toolbox.library import (
     menu_reboot_server,
     finish_node,
     pull_harmony_update,
-    version_checks
+    version_checks,
+    harmony_service_status
 )
 
 def collect_rewards(networkCall):
@@ -405,16 +406,6 @@ def run_regular_node(software_versions) -> None:
                 print_stars()
                 input()
                 start_regular_node()
-
-def harmony_service_status(service = "harmony") -> None:
-    status = subprocess.call(["systemctl", "is-active", "--quiet", service])
-    if status == 0:
-        if service == "harmony":
-            print(f"* {service} Service is:               " + Fore.BLACK + Back.GREEN + "   Online  " + Style.RESET_ALL + Fore.GREEN)
-        else:
-            print(f"* {service} Service is:              " + Fore.BLACK + Back.GREEN + "   Online  " + Style.RESET_ALL + Fore.GREEN)
-    else:
-        print(f"* {service} Service is:               " + Fore.WHITE + Back.RED + "  *** Offline *** " + Style.RESET_ALL + Fore.GREEN)
 
 def service_menu_option() -> None:
     status = os.system("systemctl is-active --quiet harmony")

--- a/src/toolbox/toolbox.py
+++ b/src/toolbox/toolbox.py
@@ -36,7 +36,8 @@ from toolbox.library import (
     harmony_service_status,
     loader_intro,
     get_folders,
-    stats_output_regular
+    stats_output_regular,
+    get_db_size
 )
 
 
@@ -649,13 +650,6 @@ def refresh_stats(clear=0) -> str:
     print(f"* Getting the latest local & blockchain information now, one moment while we load...")
     print_stars()
     return
-
-
-def get_db_size(harmony_dir, our_shard) -> str:
-    harmony_db_size = subprocess.getoutput(f"du -h {harmony_dir}/harmony_db_{our_shard}")
-    harmony_db_size = harmony_db_size.rstrip("\t")
-    countTrim = len(EnvironmentVariables.harmony_dir) + 13
-    return harmony_db_size[:-countTrim]
 
 
 def shard_stats(our_shard) -> str:

--- a/src/toolbox/toolbox.py
+++ b/src/toolbox/toolbox.py
@@ -36,7 +36,7 @@ from toolbox.library import (
     harmony_service_status,
     loader_intro,
     get_folders,
-    stats_output_regular,
+    validator_stats_output,
     get_db_size
 )
 
@@ -57,14 +57,15 @@ def parse_flags(parser):
 
     if args.stats:
         run_multistats()
-        return SystemExit(0)
+        raise SystemExit(0)
 
 
 def run_multistats():
     loader_intro()
     refresh_stats(1)
     folders = get_folders()
-    stats_output_regular(folders)
+    validator_stats_output(folders)
+    return
 
 
 def collect_rewards(networkCall):

--- a/src/toolbox/toolbox.py
+++ b/src/toolbox/toolbox.py
@@ -57,6 +57,7 @@ def parse_flags(parser):
 
     if args.stats:
         run_multistats()
+        return SystemExit(0)
 
 
 def run_multistats():


### PR DESCRIPTION
1.0.7 now has a harmony.sh script for pulling updates and launching.

To get the script locally and ready to rock:

```
cd ~/ && wget -O harmony.sh https://raw.githubusercontent.com/easy-node-pro/harmony-toolbox/main/src/bin/harmony.sh && chmod +x harmony.sh
```

Now you'll be able to simply run `./harmony.sh` from your home directory to launch the toolbox, `./harmony.sh -s` to run stats or `./harmony.sh -h` to see the help menu and any future options that are added.

Multi-Stats script upgraded to work with `./harmony.sh -s` or `./harmony.sh --stats`